### PR TITLE
Add caching to packages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'


### PR DESCRIPTION

# Change Proposal

Add package caching to CI

## What is changing

Maven packages are cached for faster builds

## Testing

Run the CI twice in the same branch and check the [actions/setup-java](https://github.com/actions/setup-java) logs to check if packages were fetched from the cache

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
