### PR TITLE
Fix deletion of environments

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -28,11 +28,18 @@ jobs:
                 az group delete --name "${{ env.ResourceGroupName }}" --yes --no-wait
              fi
 
+      - name: Get Token To delete environment
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v1
+        with:
+          application_id: ${{ secrets.PERMISSIONS_APP_ID }}
+          application_private_key: ${{ secrets.PERMISSIONS_APP_PRIVATE_KEY }}    
+
       - name: delete environment
         run:
           gh api --method DELETE /repos/${{ github.repository}}/environments/pull-request-${{ github.event.number }}
         env:
-          GH_TOKEN: ${{ secrets.github_token }}
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
 
 
       - uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
Deletion of environments requires permissions that github_token doesn't has

# Change Proposal

Fixes environment deletion for #26 

## What is changing

Uses a token provided by an application since `github_token` doesn't has enough permissions to delete environments

Closes #26 

## Testing

Check if the environment is deleted when pr is closed

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
