### PR TITLE
Install playwright with npx instead of an action

### DIFF
--- a/actions/provision-and-deploy/action.yml
+++ b/actions/provision-and-deploy/action.yml
@@ -79,6 +79,8 @@ runs:
 
   ## Integration tests
   - uses: actions/setup-node@v1
+    with:
+      node-version: 14
 
   - name: install playwright
     shell: bash

--- a/actions/provision-and-deploy/action.yml
+++ b/actions/provision-and-deploy/action.yml
@@ -83,7 +83,6 @@ runs:
   - name: install playwright
     shell: bash
     run: npx playwright install-deps
-    working-directory: ${{ env.integration_tests_path}}
   
   # - name: install playwright dependencies
   #   shell: bash

--- a/actions/provision-and-deploy/action.yml
+++ b/actions/provision-and-deploy/action.yml
@@ -82,12 +82,13 @@ runs:
 
   - name: install playwright
     shell: bash
-    run: npx playwright install-deps
+    run: |
+      npx playwright install-deps
   
-  # - name: install playwright dependencies
-  #   shell: bash
-  #   run: npm ci
-  #   working-directory: ${{ env.integration_tests_path}}
+  - name: install playwright dependencies
+    shell: bash
+    run: npm ci
+    working-directory: ${{ env.integration_tests_path}}
 
   - name: run integration tests
     shell: bash

--- a/actions/provision-and-deploy/action.yml
+++ b/actions/provision-and-deploy/action.yml
@@ -79,7 +79,9 @@ runs:
 
   ## Integration tests
   - uses: actions/setup-node@v1
+
   - name: install playwright
+    shell: bash
     run: npx playwright install-deps
     working-directory: ${{ env.integration_tests_path}}
   

--- a/actions/provision-and-deploy/action.yml
+++ b/actions/provision-and-deploy/action.yml
@@ -79,12 +79,14 @@ runs:
 
   ## Integration tests
   - uses: actions/setup-node@v1
-  - uses: microsoft/playwright-github-action@v1
-  
-  - name: install playwright dependencies
-    shell: bash
-    run: npm ci
+  - name: install playwright
+    run: npx playwright install-deps
     working-directory: ${{ env.integration_tests_path}}
+  
+  # - name: install playwright dependencies
+  #   shell: bash
+  #   run: npm ci
+  #   working-directory: ${{ env.integration_tests_path}}
 
   - name: run integration tests
     shell: bash


### PR DESCRIPTION
# Change Proposal

## What is changing

[playwright](https://playwright.dev/) installation is no longer done via an action but with npm.

This changed is recommended by the [playwright team](https://github.com/microsoft/playwright-github-action#%EF%B8%8F-you-dont-need-this-github-action-%EF%B8%8F)

Closes #32

## Testing

Run CI/CD platform and check if integration tests still run

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
