### PR TITLE
Add embed tomcat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,14 @@
   <build>
   	<finalName>myshuttledev</finalName>
     <plugins>
+     <plugin>
+        <groupId>org.apache.tomcat.maven</groupId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
+        <version>2.2</version>
+        <configuration>
+        <port>9090</port>
+        </configuration> 
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
# Change Proposal

## What is changing

Tomcat is now embed and can be started "mvn tomcat7:run" this will start a local tomcat instance running on port 9090

the app will be available on `://localhost:9090/myshuttle`

This only affects local development environment

Closes #50 

## Testing

Please describe how change is tested

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
