### PR TITLE
Disable use SSL when connecting to mysql temporarily

### DIFF
--- a/IaC/azuredeploy.json
+++ b/IaC/azuredeploy.json
@@ -120,7 +120,7 @@
                             "name": "MyShuttleDb",
                             "type": "MySql",
                             "connectionString": 
-                                "[concat('jdbc:mysql://', reference(resourceId('Microsoft.DBforMySQL/servers',variables('serverName'))).fullyQualifiedDomainName,':3306/',variables('databaseName'),'?useSSL=true&requireSSL=false&autoReconnect=true&user=',parameters('administratorLogin'),'@', variables('serverName'),'&password=',uriComponent(parameters('administratorLoginPassword')))]"
+                                "[concat('jdbc:mysql://', reference(resourceId('Microsoft.DBforMySQL/servers',variables('serverName'))).fullyQualifiedDomainName,':3306/',variables('databaseName'),'?useSSL=false&requireSSL=false&autoReconnect=true&user=',parameters('administratorLogin'),'@', variables('serverName'),'&password=',uriComponent(parameters('administratorLoginPassword')))]"
                 
                         }
                     ]


### PR DESCRIPTION
Disable SSL when connecting to mysql temporarily until #55 is implemented

# Change Proposal

Disable use of SSL when connecting to mysql as a temporary measure

## What is changing

Connection string disables use of SSL when connecting to my sql


## Testing

Please describe how change is tested

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
