### PR TITLE
using github.token for maven publish

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Publish to GitHub Packages
       run: mvn deploy -DskipTests=true --batch-mode --no-transfer-progress
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ GITHUB.TOKEN }}


### PR DESCRIPTION
# Change Proposal

## What is changing

Using `${{ GITHUB.TOKEN }}` to publish packages - tested with customer that this works.

Might just be a slightly better way since it's one less secret to re-create? 😄 