### PR TITLE
Adds deployment info to build summary

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -123,6 +123,19 @@ jobs:
 
             Don't worry we will delete it once this Pull request is closed. :fire:
 
+      - name: add comment to PR with environment info to summary
+        if: always()
+        shell: bash
+        run: |
+            cat << EOF > $GITHUB_STEP_SUMMARY
+            :loudspeaker: We created an ephemeral environment (webapp+db) so you can test the deploy for [my shuttle pr ${{env.prNumber}}](${{ steps.deployWebApp.outputs.webapp-url }}/myshuttledev)
+
+            You can also track the deployments for this environment in [Pull request ${{ github.event.pull_request.number }} environment](/${{github.repository}}/deployments/activity_log?environment=pull-request-${{ github.event.pull_request.number }})
+
+            Don't worry we will delete it once this Pull request is closed. :fire:
+
+            EOF
+
   analyze:
     name: Security Scanning
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Change Proposal

## What is changing

Adds ephemeral environment deployment info to [build summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/)


## Testing

Check if on a PR the ephemeral environment info is shown in the build summary

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
