### PR TITLE
Add SBOM generation of docker file

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,6 +237,13 @@ jobs:
         run: |
           docker build -t ghcr.io/myshuttle:${{ github.sha }} . -f src/Dockerfile
 
+      - name: Generate SBOM (and upload to dependencies)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/myshuttle:${{ github.sha }}
+          artifact-name: sbom.spdx
+          dependency-snapshot: true
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The intent of this repo is to show some capabilities:
 - [code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) - Automatically assign pull request code reviewers  based on the file path(s) of the proposed changes.
 - [Issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)
 - [Job Summaries](https://github.blog/changelog/2022-05-09-github-actions-enhance-your-actions-with-job-summaries/)
+- Generates an SBOM with (Anchore sbom action)[hhtps://github.com/anchore/sbom-action] mostly to show (runtime found dependencies)[https://github.blog/changelog/2022-06-17-dependency-graph-has-a-rest-api-for-submitting-dependencies-detected-at-build-time/]
 
 Uses [ARM templates](), to provision the `DEV` and `QA` environments using Infrastructure as code (IaC) and GitHub Actions. The arm templates create both a WebApp and a MySql server (per environment, each environment is a separate resource group). ARM templates are checked with both [Azure Resource Manager Toolkit](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit) and [checkov](https://github.com/bridgecrewio/checkov). (can you spot the issues being flagged?)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The intent of this repo is to show some capabilities:
 - [code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) - Automatically assign pull request code reviewers  based on the file path(s) of the proposed changes.
 - [Issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)
 - [Job Summaries](https://github.blog/changelog/2022-05-09-github-actions-enhance-your-actions-with-job-summaries/)
-- Generates an SBOM with (Anchore sbom action)[hhtps://github.com/anchore/sbom-action] mostly to show (runtime found dependencies)[https://github.blog/changelog/2022-06-17-dependency-graph-has-a-rest-api-for-submitting-dependencies-detected-at-build-time/]
+- Generates an SBOM with (Anchore sbom action)[hhtps://github.com/anchore/sbom-action] mostly to show [runtime found dependencies](https://github.blog/changelog/2022-06-17-dependency-graph-has-a-rest-api-for-submitting-dependencies-detected-at-build-time/)
 
 Uses [ARM templates](), to provision the `DEV` and `QA` environments using Infrastructure as code (IaC) and GitHub Actions. The arm templates create both a WebApp and a MySql server (per environment, each environment is a separate resource group). ARM templates are checked with both [Azure Resource Manager Toolkit](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit) and [checkov](https://github.com/bridgecrewio/checkov). (can you spot the issues being flagged?)
 


### PR DESCRIPTION
# Change Proposal

Generate SBOM for docker image and upload it as [snapshot dependencies](https://github.blog/changelog/2022-06-17-dependency-graph-has-a-rest-api-for-submitting-dependencies-detected-at-build-time/)

## What is changing

SBOM is generated for docker image

## Testing

Please describe how change is tested

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
