### PR TITLE
Add dependabot version updates for composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,5 +29,14 @@ updates:
     schedule:
       interval: "monthly"
     labels:
+      - "workflows"
+      - "dependencies"
+
+  - package-ecosystem: github-actions
+    directory: "/actions" # All subdirectories outside of "/.github/workflows" must be explicitly included.
+    schedule:
+      interval: monthly
+    labels:
       - "actions"
       - "dependencies"
+      


### PR DESCRIPTION
# Change Proposal

## What is changing

Add dependabot version updates scanning for the composite actions as well

Closes #.

## Testing

Trigger version updates and check the logs

## Changes

- [ ] Requires Configuration Changes
- [ ] Requires new resources
- [ ] Database Changes
- [ ] Requires changes to monitoring
  - [ ] SREs aware of changes
- [ ] Requires Documentation changes
  - [ ] Doc Team aware of changes
- [ ] Requires changes to support playbooks
  - [ ] Playbooks updated
- [ ] Requires business approval before deployment
